### PR TITLE
Add project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ Once you are familiar with these concepts you can start drilling down into patte
 
  - Using difficulty tags, `Difficulty-Beginner`, `Difficulty-Intermediate` & `Difficulty-Expert`.
  - Using pattern categories, `Creational`, `Behavioral` and others.
- - Search for a specific pattern. Can't find one? Please report a new pattern [here](https://github.com/iluwatar/java-design-patterns/issues).
+- Search for a specific pattern. Can't find one? Please report a new pattern [here](https://github.com/iluwatar/java-design-patterns/issues).
+
+# Documentation
+
+For an overview of the repository structure and build instructions see
+[docs/project-documentation.md](docs/project-documentation.md).
 
 # How to contribute
 

--- a/docs/project-documentation.md
+++ b/docs/project-documentation.md
@@ -1,0 +1,32 @@
+# Project Documentation
+
+This document provides an overview of the repository structure and how to work with the design pattern samples.
+
+## Repository Structure
+
+The project is organized as a multi-module Maven build. Each design pattern resides in its own module under the project root. Within a pattern module you'll find the source code under `src/main/java` and short documentation in an `index.md` file.
+
+```
+<pattern-name>/
+  ├── pom.xml
+  ├── src/
+  │   └── main/java/...
+  └── index.md
+```
+
+The root `pom.xml` aggregates all pattern modules so you can build everything in one command.
+
+## Building the Project
+
+To compile all examples and run the available tests, use Maven from the project root:
+
+```bash
+mvn clean install
+```
+
+This command builds every pattern module and executes any unit tests they contain.
+
+## Contributing
+
+Contributions are welcome! See the main `README.md` for details on how to get started and a link to the project's developer wiki.
+


### PR DESCRIPTION
## Summary
- document repository layout in new project-documentation.md
- link documentation from README

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684054136470832b96a3764c194b0142